### PR TITLE
Changing z-index to prevent cursor hidden fixes #19

### DIFF
--- a/vimderbar.css
+++ b/vimderbar.css
@@ -55,3 +55,9 @@
     background: rgba(255, 255, 0, .4) !important;
     /* doesn't work ?*/
 }
+
+
+.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor {
+    z-index: 100 !important;
+    background: rgba(67, 216, 145, 0.5) !important;
+}


### PR DESCRIPTION
Hi!, i found the hidden cursor problem inside tags. The problem was related
to the block cursor being overlapping by the tag background. 

![index html brackets 2013-12-21 18-31-56](https://f.cloud.github.com/assets/99183/1796761/23359ad0-6a88-11e3-95ac-c94d13269b38.png)
